### PR TITLE
chore: configure connection filter plugin

### DIFF
--- a/packages/query/package.json
+++ b/packages/query/package.json
@@ -49,7 +49,7 @@
     "pg": "^8.7.1",
     "postgraphile": "^4.12.9",
     "postgraphile-core": "^4.12.2",
-    "postgraphile-plugin-connection-filter": "^2.2.2",
+    "postgraphile-plugin-connection-filter": "^2.3.0",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.5.2",

--- a/packages/query/src/graphql/graphql.module.ts
+++ b/packages/query/src/graphql/graphql.module.ts
@@ -82,6 +82,11 @@ export class GraphqlModule implements OnModuleInit, OnModuleDestroy {
     const dbSchema = await this.projectService.getProjectSchema(this.config.get('name'));
 
     let options: PostGraphileCoreOptions = {
+      graphileBuildOptions: {
+        // To support root-level, many-to-one filtering
+        // see: https://github.com/graphile-contrib/postgraphile-plugin-connection-filter/blob/master/docs/examples.md#relations-root-level-many-to-one
+        connectionFilterRelations: true,
+      },
       replaceAllPlugins: plugins,
       subscriptions: true,
       dynamicJson: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3706,7 +3706,7 @@ __metadata:
     pg: ^8.7.1
     postgraphile: ^4.12.9
     postgraphile-core: ^4.12.2
-    postgraphile-plugin-connection-filter: ^2.2.2
+    postgraphile-plugin-connection-filter: ^2.3.0
     reflect-metadata: ^0.1.13
     rimraf: ^3.0.2
     rxjs: ^7.5.2
@@ -13435,7 +13435,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postgraphile-plugin-connection-filter@npm:^2.2.2":
+"postgraphile-plugin-connection-filter@npm:^2.3.0":
   version: 2.3.0
   resolution: "postgraphile-plugin-connection-filter@npm:2.3.0"
   dependencies:


### PR DESCRIPTION
### Changes

- updates postgraphile-plugin-connection-filter to version ^2.3.0
- adds `graphileBuildOptions` which enable [`connectionFilterRelations`](https://github.com/graphile-contrib/postgraphile-plugin-connection-filter/blob/master/docs/examples.md#relations-root-level-many-to-one) support